### PR TITLE
Fix debug message in get_variants

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,7 +229,7 @@ def get_variants(blueprint_id, print_provider_id, token):
     response = requests.get(url, headers=headers)
     data = response.json()
 
-    print(f"Response from Printify API:All Variant Recieved Suceesfully") # Debugging print
+    logging.debug("Response from Printify API: All variants received successfully")
 
     # Get the list of variants from the response data
     variants = data['variants']


### PR DESCRIPTION
## Summary
- update the debug log in `get_variants` to use proper spelling and logging

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684211e86008832b966e466f46571628